### PR TITLE
Disable the home key unlock setting, removed breaking build

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -94,8 +94,8 @@
     <!-- Allow the menu hard key to be disabled in LockScreen on some devices -->
     <bool name="config_disableMenuKeyInLockScreen">true</bool>
 
-    <!-- Disable the home key unlock setting -->
-    <bool name="config_disableHomeUnlockSetting">false</bool>
+    <!-- Disable the home key unlock setting 
+    <bool name="config_disableHomeUnlockSetting">false</bool> -->
 
     <!-- Workaround for devices with broken keyboards -->
     <bool name="config_forceDisableHardwareKeyboard">true</bool>


### PR DESCRIPTION
Not sure if it's getting added back, removed and now compiles fine.
